### PR TITLE
Add importlib import mode in pytest options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ show_error_codes = true
 
 [tool.pytest.ini_options]
 filterwarnings = ["error"]
+addopts = ["--import-mode=importlib"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This is the recommended configuration, see:
https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html#tests-outside-application-code
