### PR TITLE
Don't run non-live tests in the cron schedule

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,11 +53,14 @@ jobs:
       - name: Run live tests (needing an internet connection)
         run: poetry run coverage run -m pytest -m live
       - name: Run static tests
+        if: github.event_name != 'schedule'
         run: poetry run coverage run -am pytest -m "not live" --disable-network
       - name: Report coverage
+        if: github.event_name != 'schedule'
         run: poetry run coverage report
       # The following step will be removed when all the project is covered with tests
       - name: Maintain 100% coverage on tested modules
+        if: github.event_name != 'schedule'
         run: |
           poetry run coverage report --fail-under 100 \
           xil/_currencies.py \


### PR DESCRIPTION
Also, don't report and enforce coverage.
See:
https://docs.github.com/en/actions/learn-github-actions/contexts#github-context https://stackoverflow.com/questions/70281670/checking-condition-when-step-is-running-on-schedule-in-github-actions

Resolves #140.

It has to be checked on the next scheduled run.