### PR TITLE
Fix GitHub actions jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20240324.2.0]
         python-version: ["3.12"]
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
The "tests" workflow started to fail without any direct change:
https://github.com/jond01/xil/actions/runs/8589628189 (Apr. 7)

Try to fix the OS version as a first step, although the chronology doesn't seem exactly related.