### PR TITLE
Remove the `uv python install` step

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -33,6 +33,9 @@ jobs:
           version: ${{ steps.uv-version.outputs.version }}
           enable-cache: true
           cache-dependency-glob: uv.lock
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
       - name: Install Python
         run: uv python install
       - name: Install dependencies

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -45,4 +45,4 @@ jobs:
       - name: Run pre-commit
         env:
           PRE_COMMIT_COLOR: always
-        run: uv run --offline pre-commit run --all-files
+        run: uv run pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,7 +26,7 @@ jobs:
         id: uv-version
         run: |
           content=$(cat .github/workflows/uv-constraint.txt)
-          echo "version=${content#uv==}" >> "$GITHUB_OUTPUT"
+          echo "version=${content#uv==}" >> $GITHUB_OUTPUT
       - uses: astral-sh/setup-uv@v2
         with:
           version: ${{ steps.uv-version.outputs.version }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -33,9 +33,6 @@ jobs:
           version: ${{ steps.uv-version.outputs.version }}
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - uses: actions/setup-python@v5
-        with:
-          python-version-file: .python-version
       - name: Install Python
         run: uv python install
       - name: Install dependencies

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,15 +27,13 @@ jobs:
         run: |
           content=$(cat .github/workflows/uv-constraint.txt)
           echo "version=${content#uv==}" >> "$GITHUB_OUTPUT"
-      - name: Install uv
-        uses: astral-sh/setup-uv@v2
+      - uses: astral-sh/setup-uv@v2
         with:
           version: ${{ steps.uv-version.outputs.version }}
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - name: Install Python
-        run: uv python install
       - name: Install dependencies
+        # This step may also install the Python version set in the `.python-version` file on the fly if not available
         run: uv sync
       - name: Set PY
         id: set-py

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Python
         run: uv python install
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --offline
       - name: Set PY
         id: set-py
         run: echo "PY=$(python -VV | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
@@ -47,4 +47,4 @@ jobs:
       - name: Run pre-commit
         env:
           PRE_COMMIT_COLOR: always
-        run: uv run pre-commit run --all-files
+        run: uv run --offline pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Python
         run: uv python install
       - name: Install dependencies
-        run: uv sync --offline
+        run: uv sync
       - name: Set PY
         id: set-py
         run: echo "PY=$(python -VV | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,7 @@ jobs:
         run: |
           content=$(cat .github/workflows/uv-constraint.txt)
           echo "version=${content#uv==}" >> "$GITHUB_OUTPUT"
-      - name: Install uv
-        uses: astral-sh/setup-uv@v2
+      - uses: astral-sh/setup-uv@v2
         with:
           version: ${{ steps.uv-version.outputs.version }}
       - name: Build the package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         id: uv-version
         run: |
           content=$(cat .github/workflows/uv-constraint.txt)
-          echo "version=${content#uv==}" >> "$GITHUB_OUTPUT"
+          echo "version=${content#uv==}" >> $GITHUB_OUTPUT
       - uses: astral-sh/setup-uv@v2
         with:
           version: ${{ steps.uv-version.outputs.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,20 +51,20 @@ jobs:
       - name: Install Python
         run: uv python install ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --offline
       - name: Run live tests (needing an internet connection)
-        run: uv run coverage run -m pytest -m live
+        run: uv run --offline coverage run -m pytest -m live
       - name: Run offline tests
         if: github.event_name != 'schedule'
-        run: uv run coverage run -am pytest -m "not live" --disable-network
+        run: uv run --offline coverage run -am pytest -m "not live" --disable-network --offline
       - name: Report coverage
         if: github.event_name != 'schedule'
-        run: uv run coverage report
+        run: uv run --offline coverage report
       # The following step will be removed when all the project is covered with tests
       - name: Maintain 100% coverage on tested modules
         if: github.event_name != 'schedule'
         run: |
-          uv run coverage report --fail-under 100 \
+          uv run --offline coverage report --fail-under 100 \
           xil/_currencies.py \
           xil/_headers.py \
           xil/_df_normalizer.py \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,9 +50,6 @@ jobs:
           cache-dependency-glob: uv.lock
       - name: Install Python
         run: uv python install ${{ matrix.python-version }}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: uv sync
       - name: Run live tests (needing an internet connection)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,9 @@ jobs:
           cache-dependency-glob: uv.lock
       - name: Install Python
         run: uv python install ${{ matrix.python-version }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: uv sync
       - name: Run live tests (needing an internet connection)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         id: uv-version
         run: |
           content=$(cat .github/workflows/uv-constraint.txt)
-          echo "version=${content#uv==}" >> "$GITHUB_OUTPUT"
+          echo "version=${content#uv==}" >> $GITHUB_OUTPUT
       - uses: astral-sh/setup-uv@v2
         with:
           version: ${{ steps.uv-version.outputs.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
         run: uv run --offline coverage run -m pytest -m live
       - name: Run offline tests
         if: github.event_name != 'schedule'
-        run: uv run --offline coverage run -am pytest -m "not live" --disable-network --offline
+        run: uv run --offline coverage run -am pytest -m "not live" --disable-network
       - name: Report coverage
         if: github.event_name != 'schedule'
         run: uv run --offline coverage report

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       FORCE_COLOR: 1
+      UV_PYTHON: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v4
       - name: Get uv version
@@ -42,15 +43,13 @@ jobs:
         run: |
           content=$(cat .github/workflows/uv-constraint.txt)
           echo "version=${content#uv==}" >> "$GITHUB_OUTPUT"
-      - name: Install uv
-        uses: astral-sh/setup-uv@v2
+      - uses: astral-sh/setup-uv@v2
         with:
           version: ${{ steps.uv-version.outputs.version }}
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - name: Install Python
-        run: uv python install ${{ matrix.python-version }}
       - name: Install dependencies
+        # This step may also install the Python version set by the `UV_PYTHON` env var on the fly if not available
         run: uv sync
       - name: Run live tests (needing an internet connection)
         run: uv run --offline coverage run -m pytest -m live

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,18 +52,18 @@ jobs:
         # This step may also install the Python version set by the `UV_PYTHON` env var on the fly if not available
         run: uv sync
       - name: Run live tests (needing an internet connection)
-        run: uv run --offline coverage run -m pytest -m live
+        run: uv run coverage run -m pytest -m live
       - name: Run offline tests
         if: github.event_name != 'schedule'
-        run: uv run --offline coverage run -am pytest -m "not live" --disable-network
+        run: uv run coverage run -am pytest -m "not live" --disable-network
       - name: Report coverage
         if: github.event_name != 'schedule'
-        run: uv run --offline coverage report
+        run: uv run coverage report
       # The following step will be removed when all the project is covered with tests
       - name: Maintain 100% coverage on tested modules
         if: github.event_name != 'schedule'
         run: |
-          uv run --offline coverage report --fail-under 100 \
+          uv run coverage report --fail-under 100 \
           xil/_currencies.py \
           xil/_headers.py \
           xil/_df_normalizer.py \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Python
         run: uv python install ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync --offline
+        run: uv sync
       - name: Run live tests (needing an internet connection)
         run: uv run --offline coverage run -m pytest -m live
       - name: Run offline tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dev-dependencies = [
     "mypy>=1.11.2",
     "pandas-stubs>=2.2.2.240807",
 ]
-offline = true
 
 [tool.ruff]
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev-dependencies = [
     "mypy>=1.11.2",
     "pandas-stubs>=2.2.2.240807",
 ]
+offline = true
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
Instead, use the system's Python (when available) through the `UV_PYTHON` env var or the `.python-version` file - the default.